### PR TITLE
Fix build on HP-PA and MIPS64

### DIFF
--- a/include/zrtp_config.h
+++ b/include/zrtp_config.h
@@ -119,6 +119,34 @@
  */
 #define ZRTP_BYTE_ORDER ZBO_LITTLE_ENDIAN
 
+#elif defined(__hppa__) || defined(__hppa64__)
+
+/*
+ * PA-RISC, big endian
+ */
+#define ZRTP_BYTE_ORDER ZBO_BIG_ENDIAN
+
+#elif defined(__alpha__)
+
+/*
+ * Alpha, little endian
+ */
+#define ZRTP_BYTE_ORDER ZBO_LITTLE_ENDIAN
+
+#elif defined(__MIPSEB__)
+
+/*
+ * MIPS, big endian
+ */
+#define ZRTP_BYTE_ORDER ZBO_BIG_ENDIAN
+
+#elif defined(__MIPSEL__)
+
+/*
+ * MIPS, little endian
+ */
+#define ZRTP_BYTE_ORDER ZBO_LITTLE_ENDIAN
+
 #endif /* Automatic byte order detection */
 
 #endif


### PR DESCRIPTION
This change includes several contributions from OpenBSD ports tree, namely
patches by miod@ ("Recognize hppa as a big-endian platform and unbreak on this
arch. Bump VERSION."), landry@ ("Fix on alpha by defining endianness..") and
visa@ ("Fix build on mips64.") as can be found in RCS history of file
"telephony/libzrtp/patches/patch-include_zrtp_config_h" of "ports" repository.

To the best of my knowledge this fix applies to other platforms and breaks nothing.