### PR TITLE
Endianness on HP-PA and Alpha

### DIFF
--- a/include/zrtp_config.h
+++ b/include/zrtp_config.h
@@ -119,6 +119,20 @@
  */
 #define ZRTP_BYTE_ORDER ZBO_LITTLE_ENDIAN
 
+#elif defined(__hppa__) || defined(__hppa64__)
+
+/*
+ * PA-RISC, big endian
+ */
+#define ZRTP_BYTE_ORDER ZBO_BIG_ENDIAN
+
+#elif defined(__alpha__)
+
+/*
+ * Alpha, little endian
+ */
+#define ZRTP_BYTE_ORDER ZBO_LITTLE_ENDIAN
+
 #endif /* Automatic byte order detection */
 
 #endif


### PR DESCRIPTION
This change combines several revisions of the patches from OpenBSD ports tree.
Credits go to Miod Vallat (miod@) and Landry Breuil (landry@).