### PR TITLE
Fix building of tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,18 +87,68 @@ libzrtp_a_SOURCES = $(top_srcdir)/src/zrtp.c \
 					$(top_srcdir)/src/zrtp_iface_cache.c
 					$(top_srcdir)/src/zrtp_engine_driven.c
 
-check_PROGRAMS = cache_test
+check_PROGRAMS = cache_test cipher_test dh_test dk_test ecdh_test enrollment_test go_secure_test \
+				 hash_test minor_bugs_test sasrelay_test srtp_replay_test zrtphash_test
 
-cache_test_CPPFLAGS = 	-I$(top_srcdir)/include \
+TESTS = 		 cache_test cipher_test dh_test dk_test ecdh_test enrollment_test go_secure_test \
+				 hash_test minor_bugs_test sasrelay_test srtp_replay_test zrtphash_test
+
+TEST_CPPFLAGS = 	-I$(top_srcdir)/include \
 			-I$(top_srcdir)/. \
 			-I$(top_srcdir)/test \
 			-I$(top_srcdir)/test/cmockery \
 			-I$(top_srcdir)/third_party/bgaes \
 			-I$(top_srcdir)/third_party/bnlib
 
-cache_test_SOURCES = $(top_srcdir)/test/cmockery/cmockery.c \
-					 $(top_srcdir)/test/cache_test.c
+cache_test_CPPFLAGS = $(TEST_CPPFLAGS)
+cache_test_SOURCES = $(top_srcdir)/test/cmockery/cmockery.c $(top_srcdir)/test/cache_test.c
 cache_test_LDADD   = libzrtp.a  $(top_srcdir)/third_party/bnlib/libbn.a -lpthread
+
+cipher_test_CPPFLAGS = $(TEST_CPPFLAGS)
+cipher_test_SOURCES = $(top_srcdir)/test/cmockery/cmockery.c $(top_srcdir)/test/cipher_test.c
+cipher_test_LDADD   = libzrtp.a  $(top_srcdir)/third_party/bnlib/libbn.a -lpthread
+
+dh_test_CPPFLAGS = $(TEST_CPPFLAGS)
+dh_test_SOURCES = $(top_srcdir)/test/cmockery/cmockery.c $(top_srcdir)/test/dh_test.c
+dh_test_LDADD   = libzrtp.a  $(top_srcdir)/third_party/bnlib/libbn.a -lpthread
+
+dk_test_CPPFLAGS = $(TEST_CPPFLAGS)
+dk_test_SOURCES = $(top_srcdir)/test/cmockery/cmockery.c $(top_srcdir)/test/dk_test.c
+dk_test_LDADD   = libzrtp.a  $(top_srcdir)/third_party/bnlib/libbn.a -lpthread
+
+ecdh_test_CPPFLAGS = $(TEST_CPPFLAGS)
+ecdh_test_SOURCES = $(top_srcdir)/test/cmockery/cmockery.c $(top_srcdir)/test/ecdh_test.c
+ecdh_test_LDADD   = libzrtp.a  $(top_srcdir)/third_party/bnlib/libbn.a -lpthread
+
+enrollment_test_CPPFLAGS = $(TEST_CPPFLAGS)
+enrollment_test_SOURCES = $(top_srcdir)/test/cmockery/cmockery.c $(top_srcdir)/test/enrollment_test.c $(top_srcdir)/test/test_engine.c $(top_srcdir)/test/queue.c
+enrollment_test_LDADD   = libzrtp.a  $(top_srcdir)/third_party/bnlib/libbn.a -lpthread
+
+go_secure_test_CPPFLAGS = $(TEST_CPPFLAGS)
+go_secure_test_SOURCES = $(top_srcdir)/test/cmockery/cmockery.c $(top_srcdir)/test/go_secure_test.c $(top_srcdir)/test/test_engine.c $(top_srcdir)/test/queue.c
+go_secure_test_LDADD   = libzrtp.a  $(top_srcdir)/third_party/bnlib/libbn.a -lpthread
+
+hash_test_CPPFLAGS = $(TEST_CPPFLAGS)
+hash_test_SOURCES = $(top_srcdir)/test/cmockery/cmockery.c $(top_srcdir)/test/hash_test.c
+hash_test_LDADD   = libzrtp.a  $(top_srcdir)/third_party/bnlib/libbn.a -lpthread
+
+minor_bugs_test_CPPFLAGS = $(TEST_CPPFLAGS)
+minor_bugs_test_SOURCES = $(top_srcdir)/test/cmockery/cmockery.c $(top_srcdir)/test/minor_bugs_test.c
+minor_bugs_test_LDADD   = libzrtp.a  $(top_srcdir)/third_party/bnlib/libbn.a -lpthread
+
+sasrelay_test_CPPFLAGS = $(TEST_CPPFLAGS)
+sasrelay_test_SOURCES = $(top_srcdir)/test/cmockery/cmockery.c $(top_srcdir)/test/sasrelay_test.c $(top_srcdir)/test/test_engine.c $(top_srcdir)/test/queue.c
+
+sasrelay_test_LDADD   = libzrtp.a  $(top_srcdir)/third_party/bnlib/libbn.a -lpthread
+
+srtp_replay_test_CPPFLAGS = $(TEST_CPPFLAGS)
+srtp_replay_test_SOURCES = $(top_srcdir)/test/cmockery/cmockery.c $(top_srcdir)/test/srtp_replay_test.c
+srtp_replay_test_LDADD   = libzrtp.a  $(top_srcdir)/third_party/bnlib/libbn.a -lpthread
+
+zrtphash_test_CPPFLAGS = $(TEST_CPPFLAGS)
+zrtphash_test_SOURCES = $(top_srcdir)/test/cmockery/cmockery.c $(top_srcdir)/test/zrtphash_test.c $(top_srcdir)/test/test_engine.c $(top_srcdir)/test/queue.c
+
+zrtphash_test_LDADD   = libzrtp.a  $(top_srcdir)/third_party/bnlib/libbn.a -lpthread
 
 SUBDIRS =  third_party/bnlib
 

--- a/test/cipher_test.c
+++ b/test/cipher_test.c
@@ -9,6 +9,7 @@
 
 #include <setjmp.h>
 #include <stdio.h>
+#include <stdarg.h>
 
 #include "zrtp.h"
 #include "cmockery/cmockery.h"

--- a/test/cmockery/cmockery.h
+++ b/test/cmockery/cmockery.h
@@ -48,7 +48,7 @@ int __stdcall IsDebuggerPresent();
  * pointer or integer supported by the compiler. */
 #ifndef _UINTMAX_T
 #define _UINTMAX_T
-typedef unsigned long long uintmax_t;
+//typedef unsigned long long uintmax_t;
 #endif /* _UINTMAX_T */
 
 /* Printf formats used to display uintmax_t. */

--- a/test/dh_test.c
+++ b/test/dh_test.c
@@ -9,6 +9,7 @@
 
 #include <setjmp.h>
 #include <stdio.h>
+#include <stdarg.h>
 
 #include "zrtp.h"
 #include "cmockery/cmockery.h"

--- a/test/dk_test.c
+++ b/test/dk_test.c
@@ -9,6 +9,7 @@
 
 #include <setjmp.h>
 #include <stdio.h>
+#include <stdarg.h>
 
 #include "zrtp.h"
 #include "cmockery/cmockery.h"

--- a/test/ecdh_test.c
+++ b/test/ecdh_test.c
@@ -9,6 +9,7 @@
 
 #include <setjmp.h>
 #include <stdio.h>
+#include <stdarg.h>
 
 #include "zrtp.h"
 #include "cmockery/cmockery.h"

--- a/test/engine_helpers.c
+++ b/test/engine_helpers.c
@@ -10,6 +10,8 @@
 #include <setjmp.h>		/*chmockery dependency*/
 #include <stdio.h>		/*chmockery dependency*/
 #include <unistd.h> 	/*for usleep*/
+#include <stdint.h>
+#include <stdarg.h>
 
 #include "cmockery/cmockery.h"
 #include "test_engine.h"

--- a/test/enrollment_test.c
+++ b/test/enrollment_test.c
@@ -10,6 +10,8 @@
 #include <setjmp.h>		/*chmockery dependency*/
 #include <stdio.h>		/*chmockery dependency*/
 #include <unistd.h> 	/*for usleep*/
+#include <stdarg.h>
+#include <stdint.h>
 
 #include "cmockery/cmockery.h"
 #include "test_engine.h"

--- a/test/hash_test.c
+++ b/test/hash_test.c
@@ -9,6 +9,7 @@
 
 #include <setjmp.h>
 #include <stdio.h>
+#include <stdarg.h>
 
 #include "zrtp.h"
 #include "cmockery/cmockery.h"

--- a/test/minor_bugs_test.c
+++ b/test/minor_bugs_test.c
@@ -9,6 +9,8 @@
 
 #include <setjmp.h>
 #include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
 
 #include "zrtp.h"
 #include "cmockery/cmockery.h"
@@ -33,6 +35,9 @@ void teardown() {
 static void session_init_fails_with_no_dh2k() {
 	zrtp_profile_t profile;
 	zrtp_status_t s;
+	zrtp_zid_t zid;
+
+	memset(zid, 0, sizeof(zid));
 
 	zrtp_session_t *new_session;
 
@@ -42,6 +47,7 @@ static void session_init_fails_with_no_dh2k() {
 	new_session = NULL;
 	s = zrtp_session_init(zrtp,
 			&profile,
+			zid,
 			ZRTP_SIGNALING_ROLE_INITIATOR,
 			&new_session);
 
@@ -56,6 +62,7 @@ static void session_init_fails_with_no_dh2k() {
 	new_session = NULL;
 	s = zrtp_session_init(zrtp,
 			&profile,
+			zid,
 			ZRTP_SIGNALING_ROLE_INITIATOR,
 			&new_session);
 
@@ -69,6 +76,7 @@ static void session_init_fails_with_no_dh2k() {
 	new_session = NULL;
 	s = zrtp_session_init(zrtp,
 			&profile,
+			zid,
 			ZRTP_SIGNALING_ROLE_INITIATOR,
 			&new_session);
 

--- a/test/sasrelay_test.c
+++ b/test/sasrelay_test.c
@@ -10,6 +10,8 @@
 #include <setjmp.h>		/*chmockery dependency*/
 #include <stdio.h>		/*chmockery dependency*/
 #include <unistd.h> 	/*for usleep*/
+#include <stdint.h>
+#include <stdarg.h>
 
 #include "cmockery/cmockery.h"
 #include "test_engine.h"

--- a/test/srtp_replay_test.c
+++ b/test/srtp_replay_test.c
@@ -9,6 +9,7 @@
 
 #include <setjmp.h>
 #include <stdio.h>
+#include <stdarg.h>
 
 #include "zrtp.h"
 #include "cmockery/cmockery.h"

--- a/test/test_engine.c
+++ b/test/test_engine.c
@@ -277,7 +277,7 @@ void *process_outgoing(void *param)
 
 	while (the_endpoint->is_running) {
 		zrtp_test_stream_t* stream = NULL;
-		unsigned i;
+		unsigned i = 0;
 
 		zrtp_status_t s = zrtp_status_fail;
 		zrtp_test_packet_t* packet;
@@ -318,7 +318,7 @@ void *process_outgoing(void *param)
 			rtp_hdr->ts = zrtp_hton32((uint32_t)(zrtp_time_now()/1000));
 
 			/* Get RTP body from PGP words lists */
-			word = (char*)(i ? hash_word_list_odd[packets_counter % 256] : hash_word_list_even[packets_counter % 256]);
+			word = (char*)(i++ ? hash_word_list_odd[packets_counter % 256] : hash_word_list_even[packets_counter % 256]);
 
 			zrtp_memcpy(packet->body + sizeof(zrtp_rtp_hdr_t), word, (uint32_t)strlen(word));
 			packet->length = sizeof(zrtp_rtp_hdr_t) + (uint32_t)strlen(word);
@@ -336,7 +336,7 @@ void *process_outgoing(void *param)
 
 			/* Get RTP body from PGP words lists. Put RTCP marker at the beginning */
 			zrtp_memcpy(packet->body + sizeof(zrtp_rtcp_hdr_t), "RTCP", 4);
-			word = (char*)( i ? hash_word_list_odd[packets_counter % 256] : hash_word_list_even[packets_counter % 256]);
+			word = (char*)( i++ ? hash_word_list_odd[packets_counter % 256] : hash_word_list_even[packets_counter % 256]);
 
 			zrtp_memcpy(packet->body + sizeof(zrtp_rtcp_hdr_t) + 4, word, (uint32_t)strlen(word));
 			packet->length = sizeof(zrtp_rtcp_hdr_t) + (uint32_t)strlen(word) + 4;
@@ -398,7 +398,7 @@ void zrtp_test_endpoint_config_defaults(zrtp_test_endpoint_cfg_t* cfg) {
 	zrtp_config_defaults(&cfg->zrtp);
 
 	/* Set ZRTP client id */
-	strcpy(cfg->zrtp.client_id, "zrtp-test-engine");
+	strcpy(cfg->zrtp.client_id, "zrtp-test-eng");
 
 	cfg->zrtp.is_mitm = 0;
 	cfg->zrtp.lic_mode = ZRTP_LICENSE_MODE_ACTIVE;


### PR DESCRIPTION
Build all tests and run them with `make check`. On my machine (x86_64) `go_secure_test` always fails at line 71:
```
	assert_int_equal((int)ZRTP_BIT_RS1, alice_ses_info.zrtp.matches_flags);
	assert_int_equal((int)ZRTP_BIT_RS1, alice_ses_info.zrtp.cached_flags);
```
Other tests pass.

All tests from https://github.com/traviscross/libzrtp pass too.